### PR TITLE
aml_remote: fix meson-remote when using as module

### DIFF
--- a/arch/arm64/boot/dts/amlogic/mesongxbb.dtsi
+++ b/arch/arm64/boot/dts/amlogic/mesongxbb.dtsi
@@ -609,7 +609,7 @@
 	aml_remote:meson-remote {
 		compatible = "amlogic, aml_remote";
 		dev_name = "meson-remote";
-		status = "disabled";
+		status = "okay";
 		remote_ao_offset = <0x580>; /* 0x400 + (0x20 + idx)<<2 -- old ; 0x400 + (0x60 +idx)<<2 --new   */
 		interrupts = <0 196 1>;
 		pinctrl-names = "default";

--- a/arch/arm64/boot/dts/amlogic/mesongxl.dtsi
+++ b/arch/arm64/boot/dts/amlogic/mesongxl.dtsi
@@ -678,7 +678,7 @@
 	aml_remote:meson-remote {
 		compatible = "amlogic, aml_remote";
 		dev_name = "meson-remote";
-		status = "disabled";
+		status = "okay";
 		remote_ao_offset = <0x580>; /* 0x400 + (0x20 + idx)<<2 -- old ; 0x400 + (0x60 +idx)<<2 --new   */
 		interrupts = <0 196 1>;
 		pinctrl-names = "default";

--- a/arch/arm64/boot/dts/amlogic/mesongxm.dtsi
+++ b/arch/arm64/boot/dts/amlogic/mesongxm.dtsi
@@ -762,7 +762,7 @@
 	aml_remote:meson-remote {
 		compatible = "amlogic, aml_remote";
 		dev_name = "meson-remote";
-		status = "disabled";
+		status = "okay";
 		remote_ao_offset = <0x580>; /* 0x400 + (0x20 + idx)<<2 -- old ; 0x400 + (0x60 +idx)<<2 --new   */
 		interrupts = <0 196 1>;
 		pinctrl-names = "default";

--- a/arch/arm64/boot/dts/amlogic/mesongxtvbb.dtsi
+++ b/arch/arm64/boot/dts/amlogic/mesongxtvbb.dtsi
@@ -728,7 +728,7 @@
 	meson-remote {
 		compatible = "amlogic, aml_remote";
 		dev_name = "meson-remote";
-		status = "ok";
+		status = "okay";
 		remote_ao_offset = <0x580>; /* 0x400 + (0x20 + idx)<<2 -- old ; 0x400 + (0x60 +idx)<<2 --new   */
 		interrupts = <0 196 1>;
 		pinctrl-names = "default";

--- a/drivers/amlogic/input/remote/Makefile
+++ b/drivers/amlogic/input/remote/Makefile
@@ -4,5 +4,5 @@
 
 # Each configuration option enables a list of files.
 
-obj-$(CONFIG_NEW_AM_REMOTE)		+= remote.o
-remote-objs := remote_main.o remote_func.o
+obj-$(CONFIG_NEW_AM_REMOTE)		+= meson-remote.o
+meson-remote-objs := remote_main.o remote_func.o

--- a/drivers/amlogic/input/remote/remote_main.c
+++ b/drivers/amlogic/input/remote/remote_main.c
@@ -714,7 +714,7 @@ static const struct of_device_id remote_dt_match[] = {
 	},
 	{},
 };
-
+MODULE_DEVICE_TABLE(of, remote_dt_match);
 
 static int remote_probe(struct platform_device *pdev)
 {


### PR DESCRIPTION
Enable meson-ir and meson-remote by default as they will be
blacklisted and loaded manually by modprobe.